### PR TITLE
Force RTC version to GitHub and Version 1.3.0 on Master

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ lib_deps =
 	WiFi101@~0.16.0
 	Low-Power@~1.6
 	868@~1.2.4
-	DS3232RTC
+	https://github.com/JChristensen/DS3232RTC#1.3.0
 
 [env:debug]
 build_unflags = -std=gnu++11


### PR DESCRIPTION
closes #39 

Now that the RTC library is version-specified, it will work.

basically it's grabbing through the platformIO registry the latest version of the library that is not backwards compatible, so the code breaks. And unfortunately you can't just specify the version like RTC@1.3 like the others because the platformIO registry also only has 2.X versions logged for some reason, so you have it give it the GitHub link and then the version with that.